### PR TITLE
Fix trending up/down splitting equal rows from shared pool

### DIFF
--- a/app/wrapped/data.ts
+++ b/app/wrapped/data.ts
@@ -258,7 +258,7 @@ export async function getArtistTrends(range: DateRange, limit = 15): Promise<Art
 
   const previousMap = new Map(previousArtists.map((a) => [a.artist, a.count]));
 
-  const trends: ArtistTrend[] = currentArtists
+  const allTrends: ArtistTrend[] = currentArtists
     .filter((a) => (previousMap.get(a.artist) ?? 0) >= 5)
     .map((a) => {
       const previousCount = previousMap.get(a.artist)!;
@@ -270,11 +270,19 @@ export async function getArtistTrends(range: DateRange, limit = 15): Promise<Art
         percentChange,
         imageUrl: a.imageUrl,
       };
-    })
-    .sort((a, b) => Math.abs(b.percentChange) - Math.abs(a.percentChange))
-    .slice(0, limit);
+    });
 
-  return trends;
+  const half = Math.floor(limit / 2);
+  const rising = allTrends
+    .filter((t) => t.percentChange >= 0)
+    .sort((a, b) => b.percentChange - a.percentChange)
+    .slice(0, half);
+  const falling = allTrends
+    .filter((t) => t.percentChange < 0)
+    .sort((a, b) => a.percentChange - b.percentChange)
+    .slice(0, half);
+
+  return [...rising, ...falling];
 }
 
 export async function getLastSyncTime(): Promise<Date | null> {


### PR DESCRIPTION
Previously, getArtistTrends sorted all artists by absolute % change and
took the top N, then the component split them into rising/falling. When
most artists moved in one direction the opposite list would be nearly empty.

Now the function independently selects the top floor(limit/2) rising and
top floor(limit/2) falling artists, guaranteeing both sections are populated.

https://claude.ai/code/session_01VCiLMwhCCyMP3ffbHxoVD5