### PR TITLE
Redesign navbar with animated sliding indicator

### DIFF
--- a/components/Layout/Header/Header.hooks.ts
+++ b/components/Layout/Header/Header.hooks.ts
@@ -1,7 +1,7 @@
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
-const MOBILE_NAV_AUTOCLOSE_DELAY_MS = 550;
+const MOBILE_NAV_AUTOCLOSE_DELAY_MS = 450;
 
 export const useHeader = () => {
   const pathname = usePathname();

--- a/components/Layout/Header/Header.hooks.ts
+++ b/components/Layout/Header/Header.hooks.ts
@@ -1,10 +1,24 @@
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+const MOBILE_NAV_AUTOCLOSE_DELAY_MS = 550;
 
 export const useHeader = () => {
   const pathname = usePathname();
 
   const [navViewable, setNavViewable] = useState(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (!navViewable) return;
+    const timer = setTimeout(() => setNavViewable(false), MOBILE_NAV_AUTOCLOSE_DELAY_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
 
   return {
     pathname,

--- a/components/Layout/Header/Header.module.css
+++ b/components/Layout/Header/Header.module.css
@@ -3,62 +3,96 @@
   padding-right: 5px;
 }
 
-.title {
+.bar {
   display: grid;
-  grid-template-columns: 10fr auto auto;
-  grid-template-rows: auto;
-  /* background-color: var(--greyBgSubtle); */
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
   padding: 5px;
+  gap: 8px;
+}
+
+.brand {
+  margin: 0;
+}
+
+.tools {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-self: end;
+}
+
+.hamburgerWrapper {
+  display: flex;
   align-items: center;
 }
 
-.nav {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: auto;
-  justify-items: center;
-  column-gap: 40px;
-  padding-bottom: 5px;
+.desktopNav {
+  display: none;
+}
+
+.mobileNav {
+  width: 100%;
+}
+
+.mobileNavInner {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0 8px;
+  gap: 2px;
 }
 
 .link {
+  position: relative;
   text-decoration-line: none;
-  width: 100%;
+  color: var(--greyText);
+  padding: 6px 12px;
+  border-radius: 8px;
   text-align: center;
-  height: 100%;
-  padding: 5px;
-  border-radius: 5px;
+  display: inline-block;
+  transition: color 0.2s ease;
 }
 
 .link:hover {
-  background-color: var(--greyBgHover);
+  color: var(--colours_primary_text_default);
 }
 
-.activeLink {
-  background-color: var(--greyBgActive);
+.link[data-active='true'] {
+  color: var(--colours_primary_text_default);
 }
 
-/* Phone Landscape/Tablet Portrait */
+.linkInner {
+  position: relative;
+  z-index: 1;
+}
+
+.pill {
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  background-color: var(--colours_primary_background_active);
+  z-index: 0;
+}
+
+/* Tablet+ : desktop nav inline, hamburger hidden */
 @media (min-width: 48em) {
-  .nav {
-    grid-template-columns: repeat(3, 1fr);
-  }
   .header {
     padding-left: 20px;
     padding-right: 20px;
   }
-}
 
-/* Tablet Landscape */
-@media (min-width: 62em) {
-  .nav {
-    grid-template-columns: repeat(4, 1fr);
+  .desktopNav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
   }
-}
 
-/* Laptop/Desktop */
-@media (min-width: 75em) {
-  .nav {
-    grid-template-columns: repeat(4, 1fr);
+  .hamburgerWrapper {
+    display: none;
+  }
+
+  .mobileNav {
+    display: none;
   }
 }

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -15,26 +15,12 @@ import { ThemePicker } from './ThemePicker';
 const isLinkActive = (link: HeaderLink, pathname: string | null) =>
   link.url === '/' ? pathname === link.url : !!pathname?.includes(link.url);
 
-const NavLinks = ({
-  pathname,
-  layoutId,
-  onNavigate,
-}: {
-  pathname: string | null;
-  layoutId: string;
-  onNavigate?: () => void;
-}) => (
+const NavLinks = ({ pathname, layoutId }: { pathname: string | null; layoutId: string }) => (
   <>
     {headerLinks.map((link) => {
       const active = isLinkActive(link, pathname);
       return (
-        <Link
-          href={link.url}
-          key={link.url}
-          className={styles.link}
-          data-active={active}
-          onClick={onNavigate}
-        >
+        <Link href={link.url} key={link.url} className={styles.link} data-active={active}>
           {active && (
             <motion.span
               layoutId={layoutId}
@@ -97,11 +83,7 @@ const Header = ({ title }: HeaderProps) => {
               style={{ overflow: 'hidden' }}
             >
               <div className={styles.mobileNavInner}>
-                <NavLinks
-                  pathname={_.pathname}
-                  layoutId="navPillMobile"
-                  onNavigate={() => _.setNavViewable(false)}
-                />
+                <NavLinks pathname={_.pathname} layoutId="navPillMobile" />
               </div>
             </motion.nav>
           )}

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -4,12 +4,52 @@ import React from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
 import { Squash as Hamburger } from 'hamburger-react';
+import { AnimatePresence, motion } from 'motion/react';
 
 import styles from './Header.module.css';
 import { headerLinks } from './Header.data';
 import { useHeader } from './Header.hooks';
-import { HeaderProps } from './Header.types';
+import { HeaderProps, HeaderLink } from './Header.types';
 import { ThemePicker } from './ThemePicker';
+
+const isLinkActive = (link: HeaderLink, pathname: string | null) =>
+  link.url === '/' ? pathname === link.url : !!pathname?.includes(link.url);
+
+const NavLinks = ({
+  pathname,
+  layoutId,
+  onNavigate,
+}: {
+  pathname: string | null;
+  layoutId: string;
+  onNavigate?: () => void;
+}) => (
+  <>
+    {headerLinks.map((link) => {
+      const active = isLinkActive(link, pathname);
+      return (
+        <Link
+          href={link.url}
+          key={link.url}
+          className={styles.link}
+          data-active={active}
+          onClick={onNavigate}
+        >
+          {active && (
+            <motion.span
+              layoutId={layoutId}
+              className={styles.pill}
+              transition={{ type: 'spring', stiffness: 380, damping: 30 }}
+            />
+          )}
+          <span className={styles.linkInner}>
+            {link.emoji} {link.name}
+          </span>
+        </Link>
+      );
+    })}
+  </>
+);
 
 const Header = ({ title }: HeaderProps) => {
   const _ = useHeader();
@@ -22,37 +62,50 @@ const Header = ({ title }: HeaderProps) => {
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <header className={styles.header}>
-        <div className={styles.title}>
-          <h3>
+        <div className={styles.bar}>
+          <h3 className={styles.brand}>
             <Link href="/">Jack Morrison</Link>
           </h3>
-          <ThemePicker />
-          <div style={{ marginLeft: 'auto' }}>
-            <Hamburger
-              toggled={_.navViewable}
-              toggle={_.setNavViewable}
-              size={20}
-              duration={0.2}
-              color={'var(--greyText)'}
-              rounded
-            />
+          <nav className={styles.desktopNav} aria-label="Primary">
+            <NavLinks pathname={_.pathname} layoutId="navPillDesktop" />
+          </nav>
+          <div className={styles.tools}>
+            <ThemePicker />
+            <div className={styles.hamburgerWrapper}>
+              <Hamburger
+                toggled={_.navViewable}
+                toggle={_.setNavViewable}
+                size={20}
+                duration={0.2}
+                color={'var(--greyText)'}
+                rounded
+                label="Toggle navigation"
+              />
+            </div>
           </div>
         </div>
-        {_.navViewable && (
-          <nav className={styles.nav}>
-            {headerLinks.map((link) => (
-              <Link
-                href={link.url}
-                key={link.url}
-                className={`${styles.link} ${
-                  (link.url === '/' ? _.pathname === link.url : _.pathname?.includes(link.url)) ? styles.activeLink : ''
-                }`}
-              >
-                {link.emoji} {link.name}
-              </Link>
-            ))}
-          </nav>
-        )}
+        <AnimatePresence initial={false}>
+          {_.navViewable && (
+            <motion.nav
+              key="mobile-nav"
+              className={styles.mobileNav}
+              aria-label="Primary mobile"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.25, ease: 'easeInOut' }}
+              style={{ overflow: 'hidden' }}
+            >
+              <div className={styles.mobileNavInner}>
+                <NavLinks
+                  pathname={_.pathname}
+                  layoutId="navPillMobile"
+                  onNavigate={() => _.setNavViewable(false)}
+                />
+              </div>
+            </motion.nav>
+          )}
+        </AnimatePresence>
       </header>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "gray-matter": "^4.0.3",
         "hamburger-react": "^2.5.2",
         "lodash": "^4.17.23",
+        "motion": "^12.38.0",
         "next": "16.1.6",
         "next-auth": "^5.0.0-beta.4",
         "next-mdx-remote": "^6.0.0",
@@ -8412,6 +8413,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -11658,6 +11686,47 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gray-matter": "^4.0.3",
     "hamburger-react": "^2.5.2",
     "lodash": "^4.17.23",
+    "motion": "^12.38.0",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.4",
     "next-mdx-remote": "^6.0.0",


### PR DESCRIPTION
The desktop nav is now always visible (title left / nav centered / theme picker
right at >=48em) instead of hiding behind the hamburger. The active-page
indicator is a soft accent pill that morphs/slides between links via Framer
Motion's shared layoutId, reusing the existing primary theme tokens so it
tracks the active theme. Mobile keeps the hamburger and gets its own
animated open/close plus the same morphing pill in vertical orientation.