### PR TITLE
Remove hardcoded Postgres connection string from drizzle config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/drizzle/drizzle.config.ts
+++ b/drizzle/drizzle.config.ts
@@ -1,12 +1,16 @@
 import 'drizzle/envConfig';
 import { defineConfig } from 'drizzle-kit';
 
+const url = process.env.POSTGRES_URL;
+
+if (!url) {
+  throw new Error(
+    'POSTGRES_URL is not set. Drizzle Kit needs a connection string — pull it with `vercel env pull .env.local` or export it before running drizzle-kit.',
+  );
+}
+
 export default defineConfig({
   schema: './drizzle/schema.ts',
   dialect: 'postgresql',
-  dbCredentials: {
-    url:
-      process.env.POSTGRES_URL ??
-      'postgres://default:d8ZmBa2MpLrO@ep-still-snowflake-98407531-pooler.eu-central-1.postgres.vercel-storage.com/verceldb',
-  },
+  dbCredentials: { url },
 });


### PR DESCRIPTION
## What

`drizzle/drizzle.config.ts` fell back to a real Vercel Postgres connection string — password included — whenever `POSTGRES_URL` was unset. This replaces the fallback with a required env var and a clear error.

```diff
-    url:
-      process.env.POSTGRES_URL ??
-      'postgres://default:…@ep-…-pooler.eu-central-1.postgres.vercel-storage.com/verceldb',
+const url = process.env.POSTGRES_URL;
+
+if (!url) {
+  throw new Error('POSTGRES_URL is not set. …');
+}
```

Also adds bare `.env` to `.gitignore`. Only `.env.local` and the `.env.*.local` variants were ignored, but `drizzle/envConfig.ts` calls `loadEnvConfig`, which reads plain `.env` too — so a `.env` would have been committed. That gap is how this class of leak recurs.

## Credential status

**The exposed credential has already been rotated and is dead.** This PR is cleanup and prevention, not an active-exposure fix — no urgency on merging beyond normal review.

For the record: the string was committed in 134be89 (#46) on 21 Aug 2024 and was public for roughly 23 months in this repo.

## Why history isn't rewritten

Deliberately not scrubbing git history. GitHub keeps unreachable objects fetchable by SHA after a force-push, the fork carries its own copy, and two years of public exposure means it was long since harvested. Rotation was the only effective remedy and it's done; rewriting history would churn every clone to hide a value that no longer works.

## Notes for the reviewer

- Nothing imports `drizzle.config.ts` outside the `drizzle-kit` CLI (verified by grep), so throwing cannot affect `npm run build`.
- Beyond removing the leak, this closes a related footgun: anyone who ran `npx drizzle-kit migrate` without env vars set was silently pointing migrations at the live production database. It now fails loudly instead.

## Testing

- `npm run type-check` — passes on the changed file. The two `tsconfig.json` deprecation errors (`moduleResolution=node10`, `baseUrl`) are pre-existing on `main` and unrelated.
- `npx prettier --check drizzle/drizzle.config.ts` — clean.
- ESLint not run: `eslint.config.mjs` could not resolve the `eslint` package in this environment (empty `node_modules`), which is unrelated to this change.

## Follow-up worth considering (not in this PR)

`/feed/lastfm` and `/feed/lastfm/artist/[artist]` query Postgres at build time with no error handling, so any DB problem — bad credential, cold-start timeout, brief outage — fails the entire production build. The mock in `drizzle/db.ts` covers a *missing* `POSTGRES_URL` but nothing catches a *failing query*. Happy to open a separate PR moving these to ISR with a `try`/`catch` so deploys aren't coupled to database availability.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgXJSTEtcEo57TN5dm19eh)_