### PR TITLE
Fix GitHub OAuth login by setting the provider issuer

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -9,6 +9,10 @@ export const {
     GithubProvider({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
+      // GitHub now returns an RFC 9207 `iss` param on the OAuth callback. Auth.js only
+      // validates it against `provider.issuer`, falling back to "https://authjs.dev",
+      // so without this the callback fails with CallbackRouteError.
+      issuer: 'https://github.com/login/oauth',
     }),
   ],
 });


### PR DESCRIPTION
## Problem

Sign-in via GitHub fails in production with:

```
[auth][error] CallbackRouteError
[auth][cause]: unexpected "iss" (issuer) response parameter value
[auth][details]: { "expected": "https://authjs.dev", "provider": "github" }
```

GitHub has rolled out [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207) and now appends `iss=https://github.com/login/oauth` to the OAuth callback. `oauth4webapi`'s `validateAuthResponse` compares that against `provider.issuer`; the built-in Auth.js GitHub provider doesn't set one, so `@auth/core` falls back to its placeholder `"https://authjs.dev"` and rejects the callback.

## Fix

Set `issuer: 'https://github.com/login/oauth'` on the provider. This only affects the `iss` comparison — the provider defines explicit authorization/token/userinfo URLs, so Auth.js takes the non-discovery branch and never fetches a `.well-known` document, and as a `type: 'oauth'` (not `oidc`) provider there's no id_token validation involved.

No GitHub OAuth App changes are needed. `npm run type-check` passes.

Refs: [langfuse#13091](https://github.com/langfuse/langfuse/issues/13091), [GitHub community discussion #192143](https://github.com/orgs/community/discussions/192143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)