### PR TITLE
Add a month-by-month feed to the homepage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ There are **no tests** in this project. Validation is done via `type-check` and 
 | `GITHUB_SECRET` | GitHub OAuth App client secret (NextAuth) |
 | `LASTFM_API_KEY` | Last.fm API key for music data |
 | `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics measurement ID |
+| `FEED_MOCK_SOURCES` | Dev only. Set to `1` to render stand-in GitHub/Trakt data in the homepage timeline while those tables don't exist yet. Never writes to the database; real tables always win. |
 
 The app degrades gracefully without `POSTGRES_URL` — `drizzle/db.ts` exports a mock DB object that returns empty arrays.
 

--- a/app/CartoonAvatar/CartoonAvatar.module.scss
+++ b/app/CartoonAvatar/CartoonAvatar.module.scss
@@ -897,8 +897,10 @@
   }
 
   .badge {
-    top: 24%;
-    left: 4%;
+    /* Sits high and slightly in from the edge so the feed's pinned scrap has
+       clear cork below it (see app/Timeline) without crowding the shoulder. */
+    top: 16%;
+    left: 9%;
   }
 
   .phone {

--- a/app/Corkboard/Corkboard.module.scss
+++ b/app/Corkboard/Corkboard.module.scss
@@ -568,7 +568,9 @@
 /* -------------------------------------------------------------------------- */
 
 .board {
-  padding: 18px 16px 22px;
+  /* The generous bottom padding reserves clear cork for the feed's pinned scrap
+     (see app/Timeline) — the desktop layout below resets padding to 0. */
+  padding: 18px 16px 96px;
   display: flex;
   flex-direction: column;
   gap: 18px;

--- a/app/HomeLayout.tsx
+++ b/app/HomeLayout.tsx
@@ -12,6 +12,7 @@ type Props = {
   musicStatsSlot: ReactNode;
   contributionsSlot: ReactNode;
   contributionsCardSlot: ReactNode;
+  feedSlot: ReactNode;
 };
 
 export const HomeLayout = ({
@@ -19,6 +20,7 @@ export const HomeLayout = ({
   musicStatsSlot,
   contributionsSlot,
   contributionsCardSlot,
+  feedSlot,
 }: Props) => {
   // A story stays up until you pick another object or click the same one again.
   const [active, setActive] = useState<HotspotId | null>(null);
@@ -35,6 +37,7 @@ export const HomeLayout = ({
         >
           <CartoonAvatar active={active} onActiveChange={setActive} contributionsSlot={contributionsSlot} />
         </Corkboard>
+        {feedSlot}
       </div>
     </MotionConfig>
   );

--- a/app/Timeline/MonthCard.tsx
+++ b/app/Timeline/MonthCard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { ReactNode } from 'react';
+import * as motion from 'motion/react-client';
+import type { MonthSummary } from 'data-access/feed/feed.types';
+import { ArtistTile, HeatTile, SparkTile, StatTile, TextTile } from './Tiles';
+import styles from './Timeline.module.scss';
+
+const MAX_TILES = 7;
+
+const hour12 = (h: number) => {
+  const suffix = h < 12 ? 'am' : 'pm';
+  return `${h % 12 === 0 ? 12 : h % 12}${suffix}`;
+};
+
+/**
+ * The headline numbers first, then a tile for every other source that has data,
+ * then whatever else is interesting. Dense grid flow closes any gaps left over.
+ */
+function selectTiles(m: MonthSummary): ReactNode[] {
+  const { music, github, trakt } = m;
+
+  const headline: (ReactNode | null)[] = [
+    music?.topArtist ? (
+      <ArtistTile
+        key="artist"
+        label="Top artist"
+        name={music.topArtist.name}
+        note={`${music.topArtist.count.toLocaleString()} plays`}
+        imageUrl={music.topArtist.imageUrl}
+      />
+    ) : null,
+    music ? <StatTile key="listens" label="Listens" value={music.listens.toLocaleString()} accent="primary" /> : null,
+    music ? <StatTile key="artists" label="Artists" value={String(music.artists)} /> : null,
+  ];
+
+  const sources: (ReactNode | null)[] = [
+    github ? (
+      <HeatTile
+        key="heat"
+        label="Contributions"
+        value={String(github.contributions)}
+        levels={github.levels}
+        offset={new Date(Date.UTC(m.year, m.month, 1)).getUTCDay()}
+      />
+    ) : null,
+    trakt && trakt.episodes + trakt.movies > 0 ? (
+      <StatTile
+        key="trakt"
+        label="Episodes"
+        value={String(trakt.episodes)}
+        note={trakt.movies ? `+ ${trakt.movies} film${trakt.movies > 1 ? 's' : ''}` : undefined}
+        accent="secondary"
+      />
+    ) : null,
+  ];
+
+  const extras: (ReactNode | null)[] = [
+    music && music.perDay.length > 1 ? <SparkTile key="spark" label="Listens per day" values={music.perDay} /> : null,
+    !m.isDawn && music && music.discoveries > 0 ? (
+      <StatTile key="new" label="New artists" value={String(music.discoveries)} />
+    ) : null,
+    music?.peakHour ? <StatTile key="hour" label="Peak hour" value={hour12(music.peakHour.hour)} /> : null,
+    music?.obsession && music.obsession.count >= 20 ? (
+      <TextTile
+        key="obsession"
+        label="On repeat"
+        value={music.obsession.track}
+        note={`${music.obsession.count} plays · ${music.obsession.artist}`}
+        wide
+      />
+    ) : null,
+    // Last resort, and it closes the gap on months that have fewer tiles to show.
+    music ? <StatTile key="tracks" label="Tracks" value={String(music.tracks)} /> : null,
+  ];
+
+  return [...headline, ...sources, ...extras].filter(Boolean).slice(0, MAX_TILES) as ReactNode[];
+}
+
+export const MonthCard = ({ month }: { month: MonthSummary }) => (
+  <motion.article
+    className={styles.card}
+    initial={{ opacity: 0, y: 12 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true, margin: '-40px' }}
+    transition={{ duration: 0.28, ease: [0.2, 0.8, 0.3, 1] }}
+  >
+    <div className={styles.head}>
+      <h3 className={styles.month}>
+        {month.label}
+        <span className={styles.year}>{month.year}</span>
+      </h3>
+      {month.isCurrent && <span className={styles.soFar}>so far</span>}
+      {month.music?.isRecord && <span className={styles.record}>record</span>}
+    </div>
+
+    <div className={styles.bento}>{selectTiles(month)}</div>
+  </motion.article>
+);

--- a/app/Timeline/MonthCard.tsx
+++ b/app/Timeline/MonthCard.tsx
@@ -3,78 +3,82 @@
 import { ReactNode } from 'react';
 import * as motion from 'motion/react-client';
 import type { MonthSummary } from 'data-access/feed/feed.types';
-import { ArtistTile, HeatTile, SparkTile, StatTile, TextTile } from './Tiles';
+import { ArtworkTile, HeatTile, SparkTile, StatTile } from './Tiles';
 import styles from './Timeline.module.scss';
 
-const MAX_TILES = 7;
+/*
+  Enough to fill the grid on a full month: four rows of four, with the two square
+  artwork tiles each two rows deep.
+*/
+const MAX_TILES = 12;
 
 const hour12 = (h: number) => {
   const suffix = h < 12 ? 'am' : 'pm';
   return `${h % 12 === 0 ? 12 : h % 12}${suffix}`;
 };
 
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
 /**
- * The headline numbers first, then a tile for every other source that has data,
- * then whatever else is interesting. Dense grid flow closes any gaps left over.
+ * Order is the layout: auto-flow places these row by row into the four-column
+ * grid, which puts the top artist top-left and the most-played track low and to
+ * the right — they carry the same picture often enough that any two artwork
+ * tiles near each other read as a duplicate. Dense flow closes whatever gap a
+ * missing source leaves behind.
  */
 function selectTiles(m: MonthSummary): ReactNode[] {
   const { music, github, trakt } = m;
 
-  const headline: (ReactNode | null)[] = [
+  const tiles: (ReactNode | null)[] = [
+    // Top band: the artist, two headline counts and the month's watching.
     music?.topArtist ? (
-      <ArtistTile
+      <ArtworkTile
         key="artist"
         label="Top artist"
-        name={music.topArtist.name}
-        note={`${music.topArtist.count.toLocaleString()} plays`}
+        title={music.topArtist.name}
+        note={plural(music.topArtist.count, 'play')}
         imageUrl={music.topArtist.imageUrl}
       />
     ) : null,
     music ? <StatTile key="listens" label="Listens" value={music.listens.toLocaleString()} accent="primary" /> : null,
     music ? <StatTile key="artists" label="Artists" value={String(music.artists)} /> : null,
-  ];
-
-  const sources: (ReactNode | null)[] = [
+    trakt && trakt.episodes > 0 ? (
+      <StatTile key="episodes" label="TV episodes" value={String(trakt.episodes)} accent="secondary" />
+    ) : null,
     github ? (
       <HeatTile
         key="heat"
-        label="Contributions"
+        label="GitHub contributions"
         value={String(github.contributions)}
         levels={github.levels}
         offset={new Date(Date.UTC(m.year, m.month, 1)).getUTCDay()}
       />
     ) : null,
-    trakt && trakt.episodes + trakt.movies > 0 ? (
-      <StatTile
-        key="trakt"
-        label="Episodes"
-        value={String(trakt.episodes)}
-        note={trakt.movies ? `+ ${trakt.movies} film${trakt.movies > 1 ? 's' : ''}` : undefined}
-        accent="secondary"
-      />
+    trakt && trakt.movies > 0 ? (
+      <StatTile key="films" label="Films" value={String(trakt.movies)} accent="secondary" />
     ) : null,
-  ];
 
-  const extras: (ReactNode | null)[] = [
-    music && music.perDay.length > 1 ? <SparkTile key="spark" label="Listens per day" values={music.perDay} /> : null,
+    // Lower band: the track, with the rest of the month's music around it.
     !m.isDawn && music && music.discoveries > 0 ? (
       <StatTile key="new" label="New artists" value={String(music.discoveries)} />
     ) : null,
     music?.peakHour ? <StatTile key="hour" label="Peak hour" value={hour12(music.peakHour.hour)} /> : null,
-    music?.obsession && music.obsession.count >= 20 ? (
-      <TextTile
+    music?.obsession ? (
+      <ArtworkTile
         key="obsession"
-        label="On repeat"
-        value={music.obsession.track}
-        note={`${music.obsession.count} plays · ${music.obsession.artist}`}
-        wide
+        label="Most played"
+        title={music.obsession.track}
+        note={`${music.obsession.artist} · ${plural(music.obsession.count, 'play')}`}
+        imageUrl={music.obsession.imageUrl}
       />
     ) : null,
-    // Last resort, and it closes the gap on months that have fewer tiles to show.
+    // Last resorts, and they close the gaps on months that have fewer tiles.
     music ? <StatTile key="tracks" label="Tracks" value={String(music.tracks)} /> : null,
+    music && music.perDay.length > 1 ? <SparkTile key="spark" label="Listens per day" values={music.perDay} /> : null,
+    github ? <StatTile key="activeDays" label="Days on GitHub" value={String(github.activeDays)} /> : null,
   ];
 
-  return [...headline, ...sources, ...extras].filter(Boolean).slice(0, MAX_TILES) as ReactNode[];
+  return tiles.filter(Boolean).slice(0, MAX_TILES) as ReactNode[];
 }
 
 export const MonthCard = ({ month }: { month: MonthSummary }) => (

--- a/app/Timeline/Tiles.tsx
+++ b/app/Timeline/Tiles.tsx
@@ -55,15 +55,19 @@ export const TextTile = ({
   </div>
 );
 
-/** The month's artist, with their artwork filling the tile behind the name. */
-export const ArtistTile = ({
+/**
+ * A square tile with artwork filling it and the title over the top — used for
+ * the month's artist and its most-played track. Square because every piece of
+ * artwork behind it is, so any other ratio crops it.
+ */
+export const ArtworkTile = ({
   label,
-  name,
+  title,
   note,
   imageUrl,
 }: {
   label: string;
-  name: string;
+  title: string;
   note: string;
   imageUrl: string | null;
 }) => {
@@ -71,51 +75,81 @@ export const ArtistTile = ({
   const cover = imageUrl && !failed;
 
   return (
-    <div className={cx(styles.tile, styles.artistTile, styles.w2, styles.h2, cover && styles.hasCover)}>
+    <div className={cx(styles.tile, styles.artTile, cover && styles.hasCover)}>
       {cover && (
         <>
           <Image
-            className={styles.artistCover}
+            className={styles.artCover}
             src={imageUrl}
             alt=""
             fill
-            sizes="(min-width: 48em) 50vw, 100vw"
+            sizes="(min-width: 48em) 25vw, 50vw"
             onError={() => setFailed(true)}
           />
-          <span className={styles.artistScrim} />
+          <span className={styles.artScrim} />
         </>
       )}
       {!cover && (
-        <span className={styles.artistArt}>
-          <ArtistImage src="" alt={name} size={88} />
+        <span className={styles.artFallback}>
+          <ArtistImage src="" alt={title} size={72} />
         </span>
       )}
-      <span className={styles.artistText}>
-        <span className={styles.textValue} title={name}>
-          {name}
+      <span className={styles.artText}>
+        <span className={styles.textValue} title={title}>
+          {title}
         </span>
-        <span className={styles.note}>{note}</span>
+        <span className={styles.note} title={note}>
+          {note}
+        </span>
         <span className={styles.label}>{label}</span>
       </span>
     </div>
   );
 };
 
-/** Listens per day across the month. */
+/** 1st, 2nd, 3rd, 4th — for the days at either end of the sparkline. */
+const ordinal = (n: number) => {
+  const suffix = n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th', 'st', 'nd', 'rd'][n % 10] || 'th';
+  return `${n}${suffix}`;
+};
+
+/**
+ * Listens per day across the month, with a key: the y-axis runs 0 → the month's
+ * busiest day, the x-axis the 1st → the last day, so the shape has a scale.
+ */
 export const SparkTile = ({ label, values }: { label: string; values: number[] }) => {
   if (values.length < 2) return null;
 
   const max = Math.max(...values, 1);
   const step = 100 / (values.length - 1);
-  const points = values.map((v, i) => `${(i * step).toFixed(2)},${(24 - (v / max) * 22).toFixed(2)}`);
+  const points = values.map((v, i) => `${(i * step).toFixed(2)},${(24 - (v / max) * 23).toFixed(2)}`);
 
   return (
-    <div className={cx(styles.tile, styles.w2)}>
+    <div className={cx(styles.tile, styles.w2, styles.sparkTile)}>
       <span className={styles.label}>{label}</span>
-      <svg className={styles.spark} viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
-        <polygon className={styles.sparkArea} points={`0,24 ${points.join(' ')} 100,24`} />
-        <polyline className={styles.sparkLine} points={points.join(' ')} vectorEffect="non-scaling-stroke" />
-      </svg>
+
+      <span className={styles.sparkBody}>
+        <span className={styles.sparkScale} aria-hidden="true">
+          <span>{max}</span>
+          <span>0</span>
+        </span>
+        <svg
+          className={styles.spark}
+          viewBox="0 0 100 24"
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`${label}: peak of ${max} on the busiest day`}
+        >
+          <polygon className={styles.sparkArea} points={`0,24 ${points.join(' ')} 100,24`} />
+          <polyline className={styles.sparkLine} points={points.join(' ')} vectorEffect="non-scaling-stroke" />
+          <line className={styles.sparkBase} x1="0" y1="24" x2="100" y2="24" vectorEffect="non-scaling-stroke" />
+        </svg>
+      </span>
+
+      <span className={styles.sparkFoot} aria-hidden="true">
+        <span>{ordinal(1)}</span>
+        <span>{ordinal(values.length)}</span>
+      </span>
     </div>
   );
 };

--- a/app/Timeline/Tiles.tsx
+++ b/app/Timeline/Tiles.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { ArtistImage } from 'app/wrapped/components/ArtistImage';
+import styles from './Timeline.module.scss';
+
+export type Tone = 'primary' | 'secondary';
+
+const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(' ');
+
+const tone = (t?: Tone) => (t === 'primary' ? styles.tonePrimary : t === 'secondary' ? styles.toneSecondary : undefined);
+
+/** A single big number with its label underneath. */
+export const StatTile = ({
+  label,
+  value,
+  note,
+  accent,
+}: {
+  label: string;
+  value: string;
+  note?: string;
+  accent?: Tone;
+}) => (
+  <div className={cx(styles.tile, tone(accent))}>
+    <span className={styles.statValue}>{value}</span>
+    {note && <span className={styles.note}>{note}</span>}
+    <span className={styles.label}>{label}</span>
+  </div>
+);
+
+/** Text rather than a number — a track title, a show. */
+export const TextTile = ({
+  label,
+  value,
+  note,
+  wide,
+}: {
+  label: string;
+  value: string;
+  note?: string;
+  wide?: boolean;
+}) => (
+  <div className={cx(styles.tile, wide && styles.w2)}>
+    <span className={styles.textValue} title={value}>
+      {value}
+    </span>
+    {note && (
+      <span className={styles.note} title={note}>
+        {note}
+      </span>
+    )}
+    <span className={styles.label}>{label}</span>
+  </div>
+);
+
+/** The month's artist, with their artwork filling the tile behind the name. */
+export const ArtistTile = ({
+  label,
+  name,
+  note,
+  imageUrl,
+}: {
+  label: string;
+  name: string;
+  note: string;
+  imageUrl: string | null;
+}) => {
+  const [failed, setFailed] = useState(false);
+  const cover = imageUrl && !failed;
+
+  return (
+    <div className={cx(styles.tile, styles.artistTile, styles.w2, styles.h2, cover && styles.hasCover)}>
+      {cover && (
+        <>
+          <Image
+            className={styles.artistCover}
+            src={imageUrl}
+            alt=""
+            fill
+            sizes="(min-width: 48em) 50vw, 100vw"
+            onError={() => setFailed(true)}
+          />
+          <span className={styles.artistScrim} />
+        </>
+      )}
+      {!cover && (
+        <span className={styles.artistArt}>
+          <ArtistImage src="" alt={name} size={88} />
+        </span>
+      )}
+      <span className={styles.artistText}>
+        <span className={styles.textValue} title={name}>
+          {name}
+        </span>
+        <span className={styles.note}>{note}</span>
+        <span className={styles.label}>{label}</span>
+      </span>
+    </div>
+  );
+};
+
+/** Listens per day across the month. */
+export const SparkTile = ({ label, values }: { label: string; values: number[] }) => {
+  if (values.length < 2) return null;
+
+  const max = Math.max(...values, 1);
+  const step = 100 / (values.length - 1);
+  const points = values.map((v, i) => `${(i * step).toFixed(2)},${(24 - (v / max) * 22).toFixed(2)}`);
+
+  return (
+    <div className={cx(styles.tile, styles.w2)}>
+      <span className={styles.label}>{label}</span>
+      <svg className={styles.spark} viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
+        <polygon className={styles.sparkArea} points={`0,24 ${points.join(' ')} 100,24`} />
+        <polyline className={styles.sparkLine} points={points.join(' ')} vectorEffect="non-scaling-stroke" />
+      </svg>
+    </div>
+  );
+};
+
+/**
+ * A month of contributions, in the same 0-4 buckets GitHub shades its own with.
+ * `offset` is the weekday the 1st falls on, so the columns line up as real weeks.
+ */
+export const HeatTile = ({
+  label,
+  value,
+  levels,
+  offset = 0,
+}: {
+  label: string;
+  value: string;
+  levels: number[];
+  offset?: number;
+}) => (
+  <div className={cx(styles.tile, styles.w2)}>
+    <span className={styles.heatWrap}>
+      <span>
+        <span className={styles.statValue}>{value}</span>
+        <span className={styles.label}>{label}</span>
+      </span>
+      <span className={styles.heat}>
+        {Array.from({ length: offset }, (_, i) => (
+          <span key={`pad-${i}`} className={styles.heatCell} data-empty="" />
+        ))}
+        {levels.map((level, i) => (
+          <span key={i} className={styles.heatCell} data-level={level} />
+        ))}
+      </span>
+    </span>
+  </div>
+);

--- a/app/Timeline/Timeline.module.scss
+++ b/app/Timeline/Timeline.module.scss
@@ -1,0 +1,479 @@
+/* The month timeline below the corkboard. */
+
+.feed {
+  /* Yarn takes the theme's accent so it recolours with the palette. */
+  --yarn: var(--colours_secondary_9);
+  --yarn-dark: color-mix(in srgb, var(--yarn) 55%, black);
+  --yarn-light: color-mix(in srgb, var(--yarn) 60%, white);
+  --strand: 6px;
+  --gutter: 34px;
+
+  /*
+    The strand hangs off a scrap pinned to the corkboard above, so these reach up
+    into that component's space. The feed starts exactly at the board's bottom
+    edge, so --hang is measured straight up from there.
+
+    Below 75em the board is a flex column and the scrap sits in the clear bottom
+    padding it reserves (see Corkboard.module.scss).
+  */
+  --hang: 82px;
+  --hanger-h: 50px;
+
+  /* One pin face, used by the pushpin above and by every month pin below. */
+  --pin-face:
+    radial-gradient(circle at 32% 26%, rgb(255 255 255 / 0.95) 0 12%, rgb(255 255 255 / 0) 22%),
+    radial-gradient(
+      circle at 38% 32%,
+      color-mix(in srgb, var(--yarn) 30%, white),
+      var(--yarn) 52%,
+      color-mix(in srgb, var(--yarn) 45%, black) 82%,
+      color-mix(in srgb, var(--yarn) 25%, black)
+    );
+  --pin-shadow:
+    0 3px 4px rgb(0 0 0 / 0.4),
+    inset 0 -2px 3px rgb(0 0 0 / 0.3),
+    inset 0 1px 2px rgb(255 255 255 / 0.25);
+
+  /* The twisted-fibre surface, shared by the strand and its tail. */
+  --yarn-tex:
+    repeating-linear-gradient(
+      125deg,
+      rgb(0 0 0 / 0.34) 0 1.5px,
+      rgb(0 0 0 / 0) 1.5px 3px,
+      rgb(255 255 255 / 0.3) 3px 4.5px,
+      rgb(0 0 0 / 0) 4.5px 6.5px
+    ),
+    linear-gradient(
+      to right,
+      color-mix(in srgb, var(--yarn) 55%, black) 0%,
+      var(--yarn) 42%,
+      color-mix(in srgb, var(--yarn) 60%, white) 64%,
+      color-mix(in srgb, var(--yarn) 45%, black) 100%
+    );
+
+  position: relative;
+  padding: clamp(1.75rem, 5vw, 3rem) 0 clamp(3rem, 8vw, 5rem);
+}
+
+/*
+  From 75em the board is pinned in place and its height tracks the viewport, so a
+  fixed offset cannot stay put — mirror the board's height and position the scrap
+  as a fraction of it. --board-h must match `height` on .board in Corkboard.
+
+  It hangs in the cork between the lanyard and the shoulder. That band was too
+  narrow to trust (.avatarArea is capped by `max-width: 50%`, so the avatar scales
+  with width as well as height and the lanyard drifts a couple of percent), so the
+  lanyard was raised to `top: 16%` in CartoonAvatar to open it up.
+*/
+@media (min-width: 75em) {
+  .feed {
+    --board-h: clamp(560px, calc(100dvh - 150px), 820px);
+    --hang: calc(var(--board-h) * 0.420);
+    --hanger-h: 48px;
+  }
+}
+
+/* The scrap pinned to the board that the whole strand hangs from. */
+.hanger {
+  position: absolute;
+  top: calc(-1 * var(--hang));
+  left: 2px;
+  width: 172px;
+  height: var(--hanger-h);
+  z-index: 1;
+}
+
+.scrap {
+  position: absolute;
+  inset: 6px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 12px 11px 26px;
+  text-align: left;
+  transform: rotate(-2.5deg);
+  transform-origin: 15px 4px;
+  background: hsl(46, 60%, 97%);
+  color: hsl(220, 22%, 20%);
+  font-family: var(--font-caveat), cursive;
+  font-size: 1.05rem;
+  line-height: 1.15;
+  box-shadow: 0 3px 6px rgb(0 0 0 / 0.32);
+  /* A torn lower edge rather than a clean rectangle. */
+  clip-path: polygon(
+    0 0, 100% 0, 100% 82%, 94% 96%, 88% 84%, 81% 97%, 74% 86%, 67% 98%, 60% 87%,
+    53% 97%, 46% 86%, 39% 98%, 32% 87%, 25% 97%, 18% 85%, 11% 96%, 5% 84%, 0 95%
+  );
+}
+
+/* Pushpin: domed head, a glint, and a shadow cast down the paper. */
+.pin {
+  position: absolute;
+  top: 0;
+  left: calc(var(--gutter) / 2 - 2px);
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  border-radius: 50%;
+  background: var(--pin-face);
+  box-shadow: var(--pin-shadow);
+  z-index: 2;
+}
+
+.months {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: var(--gutter) minmax(0, 1fr);
+  align-items: stretch;
+}
+
+/*
+  One continuous strand, hanging from the scrap above and dangling past the last
+  card. Drawn as a single element rather than per row, so the twist never seams.
+*/
+.yarn {
+  position: absolute;
+  /* Starts up at the pin and runs behind the scrap, so the torn edge can't leave a gap. */
+  top: calc(-1 * var(--hang) + 8px);
+  bottom: clamp(3rem, 8vw, 5rem);
+  left: calc(var(--gutter) / 2 - var(--strand) / 2);
+  width: var(--strand);
+  border-radius: calc(var(--strand) / 2);
+  background-image: var(--yarn-tex);
+  filter: drop-shadow(1px 1px 1.5px rgb(0 0 0 / 0.32));
+  z-index: 0;
+}
+
+/* The loose end, kicking out slightly and fraying away. */
+.yarn::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: var(--strand);
+  height: 34px;
+  border-radius: calc(var(--strand) / 2);
+  background-image: inherit;
+  transform: rotate(8deg);
+  transform-origin: top center;
+  mask-image: linear-gradient(to bottom, black 45%, transparent 100%);
+}
+
+.rail {
+  position: relative;
+}
+
+.rail {
+  position: relative;
+}
+
+/* Each month is pinned to the board through the strand. */
+.monthPin {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  --pin-size: 13px;
+  width: var(--pin-size);
+  height: var(--pin-size);
+  margin-left: calc(var(--pin-size) / -2);
+  border-radius: 50%;
+  background: var(--pin-face);
+  box-shadow: var(--pin-shadow);
+  z-index: 1;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  margin: 0 0 clamp(10px, 1.8vw, 16px);
+  padding: clamp(14px, 2.2vw, 20px);
+  border-radius: 18px;
+  background: var(--colours_background_soft);
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.month {
+  margin: 0;
+  font-size: var(--fontSizes_h5);
+  font-weight: var(--fontWeights_thickest);
+  letter-spacing: 0.06em;
+}
+
+.year {
+  margin-left: 6px;
+  color: var(--colours_text_soft);
+  font-weight: var(--fontWeights_default);
+  letter-spacing: 0.08em;
+}
+
+.soFar,
+.record {
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: var(--fontSizes_tiny);
+  letter-spacing: 0.06em;
+}
+
+.soFar {
+  background: var(--colours_primary_background_default);
+  color: var(--colours_primary_text_default);
+}
+
+.record {
+  background: var(--colours_secondary_background_default);
+  color: var(--colours_secondary_text_default);
+}
+
+/* Bento: tiles claim different amounts of space, dense flow closes the gaps. */
+.bento {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: minmax(82px, auto);
+  grid-auto-flow: dense;
+}
+
+@media (min-width: 48em) {
+  .bento {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+  }
+}
+
+.w2 {
+  grid-column: span 2;
+}
+
+.h2 {
+  grid-row: span 2;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-width: 0;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: var(--colours_background_default);
+}
+
+/* Colour earns its place on the headline numbers. */
+.tonePrimary {
+  background: var(--colours_primary_background_default);
+
+  .statValue {
+    color: var(--colours_primary_text_default);
+  }
+
+  .label {
+    color: var(--colours_primary_text_default);
+    opacity: 0.75;
+  }
+}
+
+.toneSecondary {
+  background: var(--colours_secondary_background_default);
+
+  .statValue {
+    color: var(--colours_secondary_text_default);
+  }
+
+  .label {
+    color: var(--colours_secondary_text_default);
+    opacity: 0.75;
+  }
+}
+
+.label {
+  display: block;
+  color: var(--colours_text_soft);
+  font-size: var(--fontSizes_tiny);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.statValue {
+  display: block;
+  font-size: clamp(1.6rem, 5vw, 2.3rem);
+  font-weight: var(--fontWeights_thickest);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.textValue {
+  font-size: var(--fontSizes_default);
+  font-weight: var(--fontWeights_thick);
+  line-height: 1.2;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: break-word;
+}
+
+.note {
+  display: block;
+  margin-top: 3px;
+  color: var(--colours_text_soft);
+  font-size: var(--fontSizes_tiny);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statValue + .label,
+.textValue + .label {
+  margin-top: 5px;
+}
+
+/* Top artist: the artwork fills the tile, the name sits over it. */
+.artistTile {
+  position: relative;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.hasCover {
+  padding: 0;
+  overflow: hidden;
+}
+
+.artistCover {
+  object-fit: cover;
+}
+
+.artistScrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgb(0 0 0 / 0.82) 0%, rgb(0 0 0 / 0.4) 45%, rgb(0 0 0 / 0.05) 100%);
+}
+
+.artistText {
+  position: relative;
+}
+
+.hasCover .artistText {
+  padding: 12px 14px;
+}
+
+/* The scrim is dark in every theme, so this text is always light. */
+.hasCover .textValue,
+.hasCover .note,
+.hasCover .label {
+  color: hsl(0, 0%, 100%);
+}
+
+.hasCover .note,
+.hasCover .label {
+  opacity: 0.82;
+}
+
+.artistArt {
+  display: block;
+  border-radius: 10px;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.artistArt img,
+.artistArt > div {
+  width: 100%;
+  height: 100%;
+}
+
+.spark {
+  width: 100%;
+  flex: 1;
+  min-height: 30px;
+  margin-top: 6px;
+  align-self: stretch;
+  overflow: visible;
+}
+
+.sparkLine {
+  fill: none;
+  stroke: var(--colours_primary_text_default);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.sparkArea {
+  fill: var(--colours_primary_text_default);
+  opacity: 0.16;
+}
+
+.heatWrap {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.heat {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 9px);
+  grid-auto-columns: 9px;
+  gap: 2px;
+  align-self: flex-end;
+}
+
+.heatCell {
+  border-radius: 2px;
+  background: var(--colours_primary_background_active);
+
+  &[data-empty] {
+    background: transparent;
+  }
+
+  &[data-level='1'] {
+    background: var(--colours_primary_7);
+  }
+  &[data-level='2'] {
+    background: var(--colours_primary_9);
+  }
+  &[data-level='3'] {
+    background: var(--colours_primary_10);
+  }
+  &[data-level='4'] {
+    background: var(--colours_primary_text_default);
+  }
+}
+
+.sentinel {
+  height: 1px;
+}
+
+.loading {
+  padding: 14px 0 0 var(--gutter);
+  color: var(--colours_text_soft);
+  font-size: var(--fontSizes_small);
+}
+
+.skeleton {
+  height: 220px;
+  margin: 0 0 clamp(10px, 1.8vw, 16px);
+  border-radius: 18px;
+  background: var(--colours_background_soft);
+  opacity: 0.6;
+}

--- a/app/Timeline/Timeline.module.scss
+++ b/app/Timeline/Timeline.module.scss
@@ -261,10 +261,6 @@
   grid-column: span 2;
 }
 
-.h2 {
-  grid-row: span 2;
-}
-
 .tile {
   display: flex;
   flex-direction: column;
@@ -345,11 +341,24 @@
   margin-top: 5px;
 }
 
-/* Top artist: the artwork fills the tile, the name sits over it. */
-.artistTile {
+/*
+  Artwork tiles — top artist, most-played track. Album art and artist shots are
+  square, so the tile is too: one column wide, with the row span that leaves it
+  the tallest thing in its band. Anything less and the band overshoots the
+  square, leaving a gap underneath it; the two share a row on narrow screens, so
+  there they need no span at all.
+*/
+.artTile {
   position: relative;
   justify-content: flex-end;
   gap: 10px;
+  aspect-ratio: 1;
+}
+
+@media (min-width: 48em) {
+  .artTile {
+    grid-row: span 2;
+  }
 }
 
 .hasCover {
@@ -357,21 +366,21 @@
   overflow: hidden;
 }
 
-.artistCover {
+.artCover {
   object-fit: cover;
 }
 
-.artistScrim {
+.artScrim {
   position: absolute;
   inset: 0;
   background: linear-gradient(to top, rgb(0 0 0 / 0.82) 0%, rgb(0 0 0 / 0.4) 45%, rgb(0 0 0 / 0.05) 100%);
 }
 
-.artistText {
+.artText {
   position: relative;
 }
 
-.hasCover .artistText {
+.hasCover .artText {
   padding: 12px 14px;
 }
 
@@ -387,24 +396,58 @@
   opacity: 0.82;
 }
 
-.artistArt {
+.artFallback {
   display: block;
   border-radius: 10px;
   overflow: hidden;
   align-self: flex-start;
 }
 
-.artistArt img,
-.artistArt > div {
-  width: 100%;
-  height: 100%;
+/* The label sits above the plot, the axis key below it. */
+.sparkTile {
+  justify-content: flex-start;
+  gap: 4px;
+}
+
+.sparkBody {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  flex: 1;
+  min-height: 34px;
+  margin-top: 2px;
+}
+
+/* Y key: the busiest day at the top of the plot, zero on the baseline. */
+.sparkScale {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  color: var(--colours_text_soft);
+  font-size: var(--fontSizes_tiny);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}
+
+/* X key: the first and last day the plot spans. */
+.sparkFoot {
+  display: flex;
+  justify-content: space-between;
+  /* Clear the y key, so the day numbers line up with the ends of the plot. */
+  padding-left: calc(2ch + 6px);
+  color: var(--colours_text_soft);
+  font-size: var(--fontSizes_tiny);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
 }
 
 .spark {
   width: 100%;
   flex: 1;
-  min-height: 30px;
-  margin-top: 6px;
+  min-width: 0;
   align-self: stretch;
   overflow: visible;
 }
@@ -422,9 +465,17 @@
   opacity: 0.16;
 }
 
+.sparkBase {
+  stroke: var(--colours_text_soft);
+  stroke-width: 1;
+  opacity: 0.35;
+}
+
 .heatWrap {
   display: flex;
-  align-items: flex-end;
+  flex: 1;
+  /* Centred, so the count and the calendar share whatever height the row takes. */
+  align-items: center;
   gap: 12px;
   justify-content: space-between;
 }
@@ -435,7 +486,6 @@
   grid-template-rows: repeat(7, 9px);
   grid-auto-columns: 9px;
   gap: 2px;
-  align-self: flex-end;
 }
 
 .heatCell {

--- a/app/Timeline/Timeline.tsx
+++ b/app/Timeline/Timeline.tsx
@@ -1,0 +1,42 @@
+import { FEED_PAGE_SIZE, getMonthSummaries } from 'data-access/feed/getMonthSummaries';
+import { TimelineStream } from './TimelineStream';
+import styles from './Timeline.module.scss';
+
+export const TimelineSkeleton = () => (
+  <section className={styles.feed} aria-hidden="true">
+    <span className={styles.yarn} />
+    <ol className={styles.months}>
+      {[0, 1, 2].map((i) => (
+        <li key={i} className={styles.row}>
+          <span className={styles.rail} />
+          <div className={styles.skeleton} />
+        </li>
+      ))}
+    </ol>
+  </section>
+);
+
+export const Timeline = async () => {
+  const all = await getMonthSummaries();
+  if (!all.length) return null;
+
+  const months = all.slice(0, FEED_PAGE_SIZE);
+  const done = months.length >= all.length;
+
+  return (
+    <section className={styles.feed} aria-label="Life feed">
+      <span className={styles.hanger} aria-hidden="true">
+        <span className={styles.scrap}>what I&apos;ve been up to</span>
+        <span className={styles.pin} />
+      </span>
+      <span className={styles.yarn} aria-hidden="true" />
+      <TimelineStream
+        initial={{
+          months,
+          nextCursor: done ? null : months[months.length - 1].key,
+          done,
+        }}
+      />
+    </section>
+  );
+};

--- a/app/Timeline/TimelineStream.tsx
+++ b/app/Timeline/TimelineStream.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FeedPage, MonthSummary } from 'data-access/feed/feed.types';
+import { MonthCard } from './MonthCard';
+import styles from './Timeline.module.scss';
+
+const Rail = () => (
+  <span className={styles.rail} aria-hidden="true">
+    <span className={styles.monthPin} />
+  </span>
+);
+
+export const TimelineStream = ({ initial }: { initial: FeedPage }) => {
+  const [months, setMonths] = useState<MonthSummary[]>(initial.months);
+  const [cursor, setCursor] = useState(initial.nextCursor);
+  const [done, setDone] = useState(initial.done);
+  const [loading, setLoading] = useState(false);
+  const sentinel = useRef<HTMLDivElement>(null);
+  const inFlight = useRef(false);
+
+  const loadMore = useCallback(async () => {
+    if (inFlight.current || done || !cursor) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/feed?cursor=${encodeURIComponent(cursor)}`);
+      if (!res.ok) throw new Error(`Feed request failed: ${res.status}`);
+      const page = (await res.json()) as FeedPage;
+      setMonths((prev) => [...prev, ...page.months]);
+      setCursor(page.nextCursor);
+      setDone(page.done);
+    } catch {
+      // Stop rather than retry forever — the months already loaded still read fine.
+      setDone(true);
+    } finally {
+      inFlight.current = false;
+      setLoading(false);
+    }
+  }, [cursor, done]);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el || done) return;
+
+    // Fires well before the sentinel is visible so scrolling never stalls.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '1200px 0px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore, done]);
+
+  return (
+    <>
+      <ol className={styles.months}>
+        {months.map((month) => (
+          <li key={month.key} className={styles.row}>
+            <Rail />
+            <MonthCard month={month} />
+          </li>
+        ))}
+      </ol>
+
+      {!done && <div ref={sentinel} className={styles.sentinel} aria-hidden="true" />}
+      {loading && <p className={styles.loading}>Loading…</p>}
+    </>
+  );
+};

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFeedPage } from 'data-access/feed/getMonthSummaries';
+
+export const revalidate = 43200;
+
+export async function GET(request: NextRequest) {
+  const cursor = request.nextUrl.searchParams.get('cursor');
+
+  try {
+    // Reads the same cached timeline the page rendered from, so this is a slice.
+    return NextResponse.json(await getFeedPage(cursor));
+  } catch {
+    return NextResponse.json({ months: [], nextCursor: null, done: true });
+  }
+}

--- a/app/api/updateLastFmData/updateLastFmData.ts
+++ b/app/api/updateLastFmData/updateLastFmData.ts
@@ -5,7 +5,8 @@ import { desc, sql } from 'drizzle-orm';
 import { db } from 'drizzle/db';
 import { listens, tracks } from 'drizzle/schema';
 import _ from 'lodash';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { FEED_CACHE_TAG } from 'data-access/feed/getMonthSummaries';
 
 const DAY = 1000 * 60 * 60 * 24;
 const DEFAULT_FROM = new Date('2024-01-01');
@@ -69,6 +70,8 @@ export const updateLastFmData = async ({ days }: { days?: number }) => {
   }
 
   revalidatePath('/feed/lastfm');
+  // The homepage timeline is cached as one whole-history computation.
+  revalidateTag(FEED_CACHE_TAG, 'max');
 
   return { total, totalPages };
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from 'react';
 import { ContributionGraph } from './ContributionGraph';
+import { Timeline, TimelineSkeleton } from './Timeline/Timeline';
 import { HomeLayout } from './HomeLayout';
 import { MusicStats } from './MusicStats';
 import { TopTrack } from './TopTrack';
@@ -10,6 +12,11 @@ export default function Page() {
       musicStatsSlot={<MusicStats />}
       contributionsSlot={<ContributionGraph />}
       contributionsCardSlot={<ContributionGraph variant="card" />}
+      feedSlot={
+        <Suspense fallback={<TimelineSkeleton />}>
+          <Timeline />
+        </Suspense>
+      }
     />
   );
 }

--- a/app/wrapped/data.ts
+++ b/app/wrapped/data.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { count, desc, eq, gte, and, lt, sql } from 'drizzle-orm';
 import { db } from 'drizzle/db';
 import { listens, tracks } from 'drizzle/schema';
+import { januaryUtcOffset, reportTz } from 'utils/reportTz';
 import type {
   DateRange,
   SummaryStats,
@@ -31,16 +32,12 @@ const MONTH_NAMES = [
 
 const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-export type ReportTz = 'America/New_York' | 'Europe/London';
-
-// I lived in London until March 2024; from 2024 onwards in NY.
-export function reportTz(year: number): ReportTz {
-  return year >= 2024 ? 'America/New_York' : 'Europe/London';
-}
+export type { ReportTz } from 'utils/reportTz';
+export { reportTz };
 
 export function yearRange(year: number): DateRange {
   // Jan 1 is always standard time: UTC-5 for NY, UTC+0 for London.
-  const offset = reportTz(year) === 'America/New_York' ? 5 : 0;
+  const offset = januaryUtcOffset(reportTz(year));
   return {
     startDate: new Date(Date.UTC(year, 0, 1, offset)),
     endDate: new Date(Date.UTC(year + 1, 0, 1, offset)),

--- a/data-access/feed/feed.types.ts
+++ b/data-access/feed/feed.types.ts
@@ -1,0 +1,65 @@
+import type { ReportTz } from 'utils/reportTz';
+
+/** A month bucket, formatted 'YYYY-MM'. */
+export type MonthKey = string;
+
+export type ArtistRef = { name: string; count: number; imageUrl: string | null };
+export type TrackRef = { track: string; artist: string; count: number; imageUrl: string | null };
+
+export type MusicMonth = {
+  listens: number;
+  artists: number;
+  tracks: number;
+  topArtist?: ArtistRef;
+  /** The single most-played track of the month. */
+  obsession?: TrackRef;
+  /** Artists heard for the very first time ever this month. */
+  discoveries: number;
+  discoveryNames: string[];
+  peakHour?: { hour: number; count: number };
+  busiestDay?: { day: number; count: number };
+  /** Listens per day-of-month, index 0 = the 1st. */
+  perDay: number[];
+  /** The most-listened month in the whole history. */
+  isRecord: boolean;
+};
+
+export type GithubMonth = {
+  contributions: number;
+  activeDays: number;
+  longestStreak: number;
+  /** Per-day contribution level 0-4, index 0 = the 1st. */
+  levels: number[];
+  topRepo?: { name: string; count: number };
+  repos?: number;
+};
+
+export type TraktMonth = {
+  episodes: number;
+  movies: number;
+  shows: number;
+  topShow?: { title: string; count: number };
+  biggestBinge?: { title: string; count: number };
+};
+
+export type MonthSummary = {
+  key: MonthKey;
+  year: number;
+  /** 0-11. */
+  month: number;
+  label: string;
+  tz: ReportTz;
+  /** The in-progress month — rendered as "so far". */
+  isCurrent: boolean;
+  /** Among the first months on record, where "new artist" counts are meaningless. */
+  isDawn: boolean;
+  music?: MusicMonth;
+  github?: GithubMonth;
+  trakt?: TraktMonth;
+};
+
+export type FeedPage = {
+  months: MonthSummary[];
+  nextCursor: MonthKey | null;
+  done: boolean;
+};

--- a/data-access/feed/getMonthSummaries.ts
+++ b/data-access/feed/getMonthSummaries.ts
@@ -1,0 +1,108 @@
+import 'server-only';
+
+import { unstable_cache } from 'next/cache';
+import { asc } from 'drizzle-orm';
+import { db } from 'drizzle/db';
+import { listens } from 'drizzle/schema';
+import { reportTzForDate } from 'utils/reportTz';
+import type { MonthSummary, FeedPage, MonthKey } from './feed.types';
+import { getMusicMonths } from './sources/music';
+import { getGithubMonths } from './sources/github';
+import { getTraktMonths } from './sources/trakt';
+
+export const FEED_CACHE_TAG = 'feed';
+export const FEED_PAGE_SIZE = 6;
+
+const MONTH_LABELS = [
+  'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
+  'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER',
+];
+
+/** Months where everything is "new" simply because the record had just started. */
+const DAWN_MONTHS = 2;
+
+const keyOf = (year: number, month: number) => `${year}-${String(month + 1).padStart(2, '0')}`;
+
+/** Each source is isolated: a missing table or a mock DB must not take out the feed. */
+async function safely<T>(load: () => Promise<Map<string, T>>): Promise<Map<string, T>> {
+  try {
+    return await load();
+  } catch {
+    return new Map<string, T>();
+  }
+}
+
+async function computeMonthSummaries(): Promise<MonthSummary[]> {
+  let earliest: Date | null = null;
+  try {
+    const row = (await db.select({ time: listens.time }).from(listens).orderBy(asc(listens.time)).limit(1))[0];
+    earliest = row?.time ?? null;
+  } catch {
+    earliest = null;
+  }
+  if (!earliest) return [];
+
+  const [music, github, trakt] = await Promise.all([
+    safely(getMusicMonths),
+    safely(getGithubMonths),
+    safely(getTraktMonths),
+  ]);
+
+  const now = new Date();
+  const currentKey = keyOf(now.getUTCFullYear(), now.getUTCMonth());
+
+  const summaries: MonthSummary[] = [];
+  let year = earliest.getUTCFullYear();
+  let month = earliest.getUTCMonth();
+  let index = 0;
+
+  while (year < now.getUTCFullYear() || (year === now.getUTCFullYear() && month <= now.getUTCMonth())) {
+    const key = keyOf(year, month);
+    const summary: MonthSummary = {
+      key,
+      year,
+      month,
+      label: MONTH_LABELS[month],
+      tz: reportTzForDate(new Date(Date.UTC(year, month, 1))),
+      isCurrent: key === currentKey,
+      isDawn: index < DAWN_MONTHS,
+      music: music.get(key),
+      github: github.get(key),
+      trakt: trakt.get(key),
+    };
+    // A month with nothing at all in it is left out rather than rendered blank.
+    if (summary.music || summary.github || summary.trakt) summaries.push(summary);
+
+    index += 1;
+    month += 1;
+    if (month > 11) {
+      month = 0;
+      year += 1;
+    }
+  }
+
+  // Newest first — the feed reads backwards in time.
+  summaries.reverse();
+  return summaries;
+}
+
+/**
+ * The whole timeline, cached. Computing all ~94 months costs about as much as
+ * computing one, so pagination is array slicing rather than more queries.
+ */
+export const getMonthSummaries = unstable_cache(computeMonthSummaries, ['feed-month-summaries'], {
+  tags: [FEED_CACHE_TAG],
+  revalidate: 60 * 60 * 12,
+});
+
+export async function getFeedPage(cursor?: MonthKey | null): Promise<FeedPage> {
+  const all = await getMonthSummaries();
+  const start = cursor ? all.findIndex((m) => m.key === cursor) + 1 : 0;
+  if (cursor && start === 0) return { months: [], nextCursor: null, done: true };
+
+  const months = all.slice(start, start + FEED_PAGE_SIZE);
+  const done = start + months.length >= all.length;
+  return { months, nextCursor: done ? null : (months[months.length - 1]?.key ?? null), done };
+}
+
+export type { MonthSummary };

--- a/data-access/feed/sources/github.ts
+++ b/data-access/feed/sources/github.ts
@@ -1,0 +1,102 @@
+import 'server-only';
+
+import { sql } from 'drizzle-orm';
+import { db } from 'drizzle/db';
+import type { GithubMonth } from '../feed.types';
+import { tableExists } from './tableExists';
+import { attachMockRepos, mockGithubDays, mocksEnabled } from './mock';
+
+type Row = Record<string, unknown>;
+const num = (v: unknown) => Number(v ?? 0);
+
+/**
+ * Reads the daily contribution counts pulsar backfills from GitHub's contributions
+ * GraphQL API. The REST Events API only retains ~90 days, so `github_events` can
+ * never carry history — daily counts are the only backfillable grain.
+ *
+ * Returns an empty map until pulsar creates the table.
+ */
+export type ContributionDay = { month: string; day: number; count: number; level: number };
+
+/** Roll daily contribution counts up into months. Shared by the real and mock paths. */
+export function buildGithubMonths(days: ContributionDay[]): Map<string, GithubMonth> {
+  const months = new Map<string, GithubMonth>();
+
+  for (const { month, day, count, level } of days) {
+    let m = months.get(month);
+    if (!m) {
+      m = { contributions: 0, activeDays: 0, longestStreak: 0, levels: [] };
+      months.set(month, m);
+    }
+    m.contributions += count;
+    if (count > 0) m.activeDays += 1;
+    m.levels[day - 1] = level;
+  }
+
+  for (const [key, m] of months) {
+    const dayCount = new Date(Number(key.slice(0, 4)), Number(key.slice(5, 7)), 0).getDate();
+    for (let i = 0; i < dayCount; i += 1) m.levels[i] = m.levels[i] ?? 0;
+    m.levels.length = dayCount;
+
+    let run = 0;
+    for (const level of m.levels) {
+      run = level > 0 ? run + 1 : 0;
+      if (run > m.longestStreak) m.longestStreak = run;
+    }
+  }
+
+  return months;
+}
+
+export async function getGithubMonths(): Promise<Map<string, GithubMonth>> {
+  if (!(await tableExists('github_contributions'))) {
+    if (!mocksEnabled()) return new Map<string, GithubMonth>();
+    const mock = buildGithubMonths(mockGithubDays());
+    attachMockRepos(mock);
+    return mock;
+  }
+
+  const res = await db.execute(sql`
+    SELECT to_char(date, 'YYYY-MM') AS mon,
+           EXTRACT(DAY FROM date) AS d,
+           count,
+           level
+    FROM github_contributions
+    ORDER BY date`);
+
+  const months = buildGithubMonths(
+    (res.rows as Row[]).map((r) => ({
+      month: String(r.mon),
+      day: num(r.d),
+      count: num(r.count),
+      level: num(r.level),
+    })),
+  );
+
+  await attachRepos(months);
+  return months;
+}
+
+/** Recent months only — `github_events` is a rolling ~90-day window. */
+async function attachRepos(months: Map<string, GithubMonth>) {
+  if (!(await tableExists('github_events'))) return;
+
+  const res = await db.execute(sql`
+    WITH r AS (
+      SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS mon,
+             repo_name,
+             COUNT(*) AS n,
+             ROW_NUMBER() OVER (PARTITION BY date_trunc('month', created_at) ORDER BY COUNT(*) DESC) AS rn,
+             COUNT(*) OVER (PARTITION BY date_trunc('month', created_at)) AS repos
+      FROM github_events
+      GROUP BY 1, 2
+    )
+    SELECT mon, repo_name, n, repos FROM r WHERE rn = 1`);
+
+  for (const r of res.rows as Row[]) {
+    const m = months.get(String(r.mon));
+    if (!m) continue;
+    m.topRepo = { name: String(r.repo_name), count: num(r.n) };
+    m.repos = num(r.repos);
+  }
+}

--- a/data-access/feed/sources/mock.ts
+++ b/data-access/feed/sources/mock.ts
@@ -1,0 +1,120 @@
+import type { TraktMonth } from '../feed.types';
+import type { ContributionDay } from './github';
+
+/**
+ * Stand-in data for the sources pulsar hasn't mirrored into Postgres yet, so the
+ * GitHub and Trakt tiles can be designed against something that looks real.
+ *
+ * Off unless FEED_MOCK_SOURCES=1, and only ever used when the real table is
+ * absent — the moment pulsar creates it, real data wins. This never writes to the
+ * database, so there is no way for invented numbers to reach production.
+ */
+export const mocksEnabled = () => process.env.FEED_MOCK_SOURCES === '1';
+
+/** Deterministic per-day noise, so numbers don't churn between renders. */
+const hash = (n: number): number => {
+  let t = (n + 0x6d2b79f5) >>> 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+const monthKey = (d: Date) => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+
+function eachDay(from: Date, cb: (date: Date, index: number) => void) {
+  const cursor = new Date(from);
+  const today = new Date();
+  let i = 0;
+  while (cursor <= today) {
+    cb(new Date(cursor), i);
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    i += 1;
+  }
+}
+
+/** GitHub's own quartile buckets. */
+const levelFor = (count: number) => (count === 0 ? 0 : count <= 2 ? 1 : count <= 5 ? 2 : count <= 9 ? 3 : 4);
+
+const REPOS = ['jackmorrison12/site', 'jackmorrison12/pulsar', 'jackmorrison12/wrapped', 'jackmorrison12/dotfiles'];
+
+/** Raw daily rows, shaped exactly like the ones the real table yields. */
+export function mockGithubDays(): ContributionDay[] {
+  const days: ContributionDay[] = [];
+
+  eachDay(new Date(Date.UTC(2019, 0, 1)), (date, i) => {
+    const weekend = date.getUTCDay() === 0 || date.getUTCDay() === 6;
+    // A slow wave so some months are visibly busier than others.
+    const wave = 0.62 + 0.38 * Math.sin(i / 47);
+    const active = hash(i * 7 + 1) < (weekend ? 0.34 : 0.83) * wave;
+    const count = active ? 1 + Math.floor(hash(i * 7 + 2) * (weekend ? 5 : 12)) : 0;
+
+    days.push({ month: monthKey(date), day: date.getUTCDate(), count, level: levelFor(count) });
+  });
+
+  return days;
+}
+
+/** `github_events` only covers a rolling ~90 days, so only recent months get repos. */
+export function attachMockRepos(months: Map<string, { topRepo?: { name: string; count: number }; repos?: number }>) {
+  [...months.keys()]
+    .sort()
+    .slice(-3)
+    .forEach((key, i) => {
+      const m = months.get(key);
+      if (!m) return;
+      m.topRepo = { name: REPOS[i % REPOS.length], count: 20 + Math.floor(hash(i * 31) * 60) };
+      m.repos = 2 + Math.floor(hash(i * 37) * 4);
+    });
+}
+
+const SHOWS = [
+  'Severance',
+  'The Bear',
+  'Slow Horses',
+  'Taskmaster',
+  'The Good Wife',
+  'Only Murders in the Building',
+  'Andor',
+];
+
+export function mockTraktMonths(): Map<string, TraktMonth> {
+  type Bucket = { episodes: number; movies: number; shows: Map<string, number>; binge?: { title: string; count: number } };
+  const buckets = new Map<string, Bucket>();
+
+  // Matches the real history, which starts in November 2023.
+  eachDay(new Date(Date.UTC(2023, 10, 1)), (date, i) => {
+    const key = monthKey(date);
+    let b = buckets.get(key);
+    if (!b) {
+      b = { episodes: 0, movies: 0, shows: new Map() };
+      buckets.set(key, b);
+    }
+
+    if (hash(i * 13 + 3) < 0.44) {
+      const title = SHOWS[Math.floor(hash(i * 13 + 6) * SHOWS.length)];
+      const isBinge = hash(i * 13 + 4) > 0.93;
+      const episodes = isBinge ? 4 + Math.floor(hash(i * 13 + 5) * 5) : 1 + Math.floor(hash(i * 13 + 8) * 2);
+
+      b.episodes += episodes;
+      b.shows.set(title, (b.shows.get(title) ?? 0) + episodes);
+      if (episodes >= 3 && episodes > (b.binge?.count ?? 0)) b.binge = { title, count: episodes };
+    }
+
+    if (hash(i * 13 + 7) < 0.07) b.movies += 1;
+  });
+
+  const months = new Map<string, TraktMonth>();
+  for (const [key, b] of buckets) {
+    if (b.episodes === 0 && b.movies === 0) continue;
+    const ranked = [...b.shows.entries()].sort((a, z) => z[1] - a[1]);
+    months.set(key, {
+      episodes: b.episodes,
+      movies: b.movies,
+      shows: b.shows.size,
+      topShow: ranked[0] ? { title: ranked[0][0], count: ranked[0][1] } : undefined,
+      biggestBinge: b.binge,
+    });
+  }
+
+  return months;
+}

--- a/data-access/feed/sources/music.ts
+++ b/data-access/feed/sources/music.ts
@@ -1,0 +1,158 @@
+import 'server-only';
+
+import { sql } from 'drizzle-orm';
+import { db } from 'drizzle/db';
+import type { MusicMonth } from '../feed.types';
+
+/**
+ * I moved London -> New York at the start of 2024, so months are bucketed in
+ * whichever zone I was living in. Keep this in step with `reportTzForDate`.
+ */
+const localTime = (col: string) =>
+  sql.raw(`(${col} AT TIME ZONE CASE WHEN ${col} < TIMESTAMPTZ '2024-01-01 00:00:00+00'
+    THEN 'Europe/London' ELSE 'America/New_York' END)`);
+
+const MONTH_OF = (col: string) => sql`date_trunc('month', ${localTime(col)})`;
+
+type Row = Record<string, unknown>;
+const num = (v: unknown) => Number(v ?? 0);
+const str = (v: unknown) => (v == null ? null : String(v));
+
+/**
+ * Every month of listening history in one pass per statistic. Computing all ~94
+ * months costs about as much as computing one, so the feed never paginates queries.
+ */
+export async function getMusicMonths(): Promise<Map<string, MusicMonth>> {
+  const [headline, top, discovery, perDay, peak, obsession] = await Promise.all([
+    db.execute(sql`
+      SELECT to_char(${MONTH_OF('l.time')}, 'YYYY-MM') AS mon,
+             COUNT(*) AS listens,
+             COUNT(DISTINCT LOWER(t.artist)) AS artists,
+             COUNT(DISTINCT (LOWER(t.name), LOWER(t.artist))) AS tracks
+      FROM listens l JOIN tracks t ON l.id = t.id
+      GROUP BY 1`),
+
+    db.execute(sql`
+      WITH m AS (
+        SELECT ${MONTH_OF('l.time')} AS mon,
+               LOWER(t.artist) AS akey,
+               MODE() WITHIN GROUP (ORDER BY t.artist) AS artist,
+               MODE() WITHIN GROUP (ORDER BY t.image_url) AS img,
+               COUNT(*) AS n,
+               ROW_NUMBER() OVER (PARTITION BY ${MONTH_OF('l.time')} ORDER BY COUNT(*) DESC) AS rn
+        FROM listens l JOIN tracks t ON l.id = t.id
+        GROUP BY 1, 2
+      )
+      SELECT to_char(mon,'YYYY-MM') AS mon, artist, n, img FROM m WHERE rn = 1`),
+
+    // "First time I ever heard this artist" — one MIN() over all history beats
+    // re-scanning the past for every month.
+    db.execute(sql`
+      WITH f AS (
+        SELECT LOWER(t.artist) AS akey,
+               MODE() WITHIN GROUP (ORDER BY t.artist) AS artist,
+               MIN(l.time) AS first_time
+        FROM listens l JOIN tracks t ON l.id = t.id
+        GROUP BY 1
+      )
+      SELECT to_char(${MONTH_OF('first_time')}, 'YYYY-MM') AS mon,
+             COUNT(*) AS n,
+             (array_agg(artist ORDER BY artist))[1:3] AS names
+      FROM f GROUP BY 1`),
+
+    db.execute(sql`
+      SELECT to_char(${MONTH_OF('l.time')}, 'YYYY-MM') AS mon,
+             EXTRACT(DAY FROM ${localTime('l.time')}) AS d,
+             COUNT(*) AS n
+      FROM listens l GROUP BY 1, 2`),
+
+    db.execute(sql`
+      WITH h AS (
+        SELECT ${MONTH_OF('l.time')} AS mon,
+               EXTRACT(HOUR FROM ${localTime('l.time')}) AS hr,
+               COUNT(*) AS n,
+               ROW_NUMBER() OVER (PARTITION BY ${MONTH_OF('l.time')} ORDER BY COUNT(*) DESC) AS rn
+        FROM listens l GROUP BY 1, 2
+      )
+      SELECT to_char(mon,'YYYY-MM') AS mon, hr, n FROM h WHERE rn = 1`),
+
+    db.execute(sql`
+      WITH w AS (
+        SELECT ${MONTH_OF('l.time')} AS mon,
+               LOWER(t.name) AS nk, LOWER(t.artist) AS ak,
+               MODE() WITHIN GROUP (ORDER BY t.name) AS nm,
+               MODE() WITHIN GROUP (ORDER BY t.artist) AS ar,
+               MODE() WITHIN GROUP (ORDER BY t.image_url) AS img,
+               COUNT(*) AS n,
+               ROW_NUMBER() OVER (PARTITION BY ${MONTH_OF('l.time')} ORDER BY COUNT(*) DESC) AS rn
+        FROM listens l JOIN tracks t ON l.id = t.id
+        GROUP BY 1, 2, 3
+      )
+      SELECT to_char(mon,'YYYY-MM') AS mon, nm, ar, img, n FROM w WHERE rn = 1`),
+  ]);
+
+  const months = new Map<string, MusicMonth>();
+  const ensure = (key: string): MusicMonth => {
+    let m = months.get(key);
+    if (!m) {
+      m = { listens: 0, artists: 0, tracks: 0, discoveries: 0, discoveryNames: [], perDay: [], isRecord: false };
+      months.set(key, m);
+    }
+    return m;
+  };
+
+  for (const r of headline.rows as Row[]) {
+    const m = ensure(String(r.mon));
+    m.listens = num(r.listens);
+    m.artists = num(r.artists);
+    m.tracks = num(r.tracks);
+  }
+
+  for (const r of top.rows as Row[]) {
+    const artist = str(r.artist);
+    if (artist) ensure(String(r.mon)).topArtist = { name: artist, count: num(r.n), imageUrl: str(r.img) };
+  }
+
+  for (const r of discovery.rows as Row[]) {
+    const m = ensure(String(r.mon));
+    m.discoveries = num(r.n);
+    m.discoveryNames = Array.isArray(r.names) ? (r.names as string[]).filter(Boolean) : [];
+  }
+
+  for (const r of perDay.rows as Row[]) {
+    const m = ensure(String(r.mon));
+    m.perDay[num(r.d) - 1] = num(r.n);
+  }
+
+  for (const r of peak.rows as Row[]) {
+    ensure(String(r.mon)).peakHour = { hour: num(r.hr), count: num(r.n) };
+  }
+
+  for (const r of obsession.rows as Row[]) {
+    const track = str(r.nm);
+    const artist = str(r.ar);
+    if (track && artist) {
+      ensure(String(r.mon)).obsession = { track, artist, count: num(r.n), imageUrl: str(r.img) };
+    }
+  }
+
+  // Fill sparkline gaps, derive the busiest day, and badge the all-time record.
+  let record = 0;
+  let recordKey: string | null = null;
+  for (const [key, m] of months) {
+    const days = new Date(Number(key.slice(0, 4)), Number(key.slice(5, 7)), 0).getDate();
+    for (let i = 0; i < days; i += 1) m.perDay[i] = m.perDay[i] ?? 0;
+    m.perDay.length = days;
+
+    const best = m.perDay.reduce((acc, n, i) => (n > m.perDay[acc] ? i : acc), 0);
+    if (m.perDay[best] > 0) m.busiestDay = { day: best + 1, count: m.perDay[best] };
+
+    if (m.listens > record) {
+      record = m.listens;
+      recordKey = key;
+    }
+  }
+  if (recordKey) months.get(recordKey)!.isRecord = true;
+
+  return months;
+}

--- a/data-access/feed/sources/music.ts
+++ b/data-access/feed/sources/music.ts
@@ -19,6 +19,12 @@ const num = (v: unknown) => Number(v ?? 0);
 const str = (v: unknown) => (v == null ? null : String(v));
 
 /**
+ * Last.fm serves the same artwork from more than one host and at more than one
+ * size, so two URLs can be the same picture. The filename is its identity.
+ */
+const coverKey = (url: string) => url.slice(url.lastIndexOf('/') + 1);
+
+/**
  * Every month of listening history in one pass per statistic. Computing all ~94
  * months costs about as much as computing one, so the feed never paginates queries.
  */
@@ -32,18 +38,33 @@ export async function getMusicMonths(): Promise<Map<string, MusicMonth>> {
       FROM listens l JOIN tracks t ON l.id = t.id
       GROUP BY 1`),
 
+    // Every cover the top artist was heard on, most-played first — the artist
+    // tile takes the first of them the track tile isn't already showing.
     db.execute(sql`
       WITH m AS (
         SELECT ${MONTH_OF('l.time')} AS mon,
                LOWER(t.artist) AS akey,
                MODE() WITHIN GROUP (ORDER BY t.artist) AS artist,
-               MODE() WITHIN GROUP (ORDER BY t.image_url) AS img,
                COUNT(*) AS n,
                ROW_NUMBER() OVER (PARTITION BY ${MONTH_OF('l.time')} ORDER BY COUNT(*) DESC) AS rn
         FROM listens l JOIN tracks t ON l.id = t.id
         GROUP BY 1, 2
+      ),
+      c AS (
+        SELECT ${MONTH_OF('l.time')} AS mon,
+               LOWER(t.artist) AS akey,
+               t.image_url AS img,
+               COUNT(*) AS n
+        FROM listens l JOIN tracks t ON l.id = t.id
+        WHERE t.image_url IS NOT NULL AND t.image_url <> ''
+        GROUP BY 1, 2, 3
+      ),
+      i AS (
+        SELECT mon, akey, array_agg(img ORDER BY n DESC, img) AS imgs FROM c GROUP BY 1, 2
       )
-      SELECT to_char(mon,'YYYY-MM') AS mon, artist, n, img FROM m WHERE rn = 1`),
+      SELECT to_char(m.mon,'YYYY-MM') AS mon, m.artist, m.n, i.imgs
+      FROM m LEFT JOIN i ON i.mon = m.mon AND i.akey = m.akey
+      WHERE m.rn = 1`),
 
     // "First time I ever heard this artist" — one MIN() over all history beats
     // re-scanning the past for every month.
@@ -108,9 +129,16 @@ export async function getMusicMonths(): Promise<Map<string, MusicMonth>> {
     m.tracks = num(r.tracks);
   }
 
+  // Kept aside until the obsession rows are in, so the two tiles can be compared.
+  const artistCovers = new Map<string, string[]>();
+
   for (const r of top.rows as Row[]) {
     const artist = str(r.artist);
-    if (artist) ensure(String(r.mon)).topArtist = { name: artist, count: num(r.n), imageUrl: str(r.img) };
+    if (!artist) continue;
+
+    const covers = Array.isArray(r.imgs) ? (r.imgs as string[]).filter(Boolean) : [];
+    artistCovers.set(String(r.mon), covers);
+    ensure(String(r.mon)).topArtist = { name: artist, count: num(r.n), imageUrl: covers[0] ?? null };
   }
 
   for (const r of discovery.rows as Row[]) {
@@ -134,6 +162,21 @@ export async function getMusicMonths(): Promise<Map<string, MusicMonth>> {
     if (track && artist) {
       ensure(String(r.mon)).obsession = { track, artist, count: num(r.n), imageUrl: str(r.img) };
     }
+  }
+
+  /*
+    The most-played track is usually by the top artist, and its cover is then the
+    artist's most-heard one too — so both tiles reach for the same picture and the
+    card looks like it is showing it twice. Drop the artist to their next cover
+    when that happens; if they only ever had the one, the tiles match and that is
+    honest.
+  */
+  for (const [key, m] of months) {
+    const taken = m.obsession?.imageUrl;
+    if (!taken || !m.topArtist?.imageUrl || coverKey(m.topArtist.imageUrl) !== coverKey(taken)) continue;
+
+    const alternative = (artistCovers.get(key) ?? []).find((img) => coverKey(img) !== coverKey(taken));
+    if (alternative) m.topArtist.imageUrl = alternative;
   }
 
   // Fill sparkline gaps, derive the busiest day, and badge the all-time record.

--- a/data-access/feed/sources/tableExists.ts
+++ b/data-access/feed/sources/tableExists.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import { sql } from 'drizzle-orm';
+import { db } from 'drizzle/db';
+
+/**
+ * The GitHub and Trakt tables are owned by pulsar and may not exist yet. Probing
+ * once is cheaper and clearer than catching error 42P01 on every query.
+ */
+export async function tableExists(name: string): Promise<boolean> {
+  try {
+    const res = await db.execute(sql`SELECT to_regclass(${`public.${name}`}) AS reg`);
+    return Boolean((res.rows[0] as { reg: string | null } | undefined)?.reg);
+  } catch {
+    return false;
+  }
+}

--- a/data-access/feed/sources/trakt.ts
+++ b/data-access/feed/sources/trakt.ts
@@ -1,0 +1,78 @@
+import 'server-only';
+
+import { sql } from 'drizzle-orm';
+import { db } from 'drizzle/db';
+import type { TraktMonth } from '../feed.types';
+import { tableExists } from './tableExists';
+import { mockTraktMonths, mocksEnabled } from './mock';
+
+type Row = Record<string, unknown>;
+const num = (v: unknown) => Number(v ?? 0);
+
+/**
+ * Trakt watch history, once pulsar mirrors it out of local SQLite into Postgres.
+ * There is no artwork or rating in the Trakt data, so tiles here are numbers only.
+ *
+ * Returns an empty map until pulsar creates the table.
+ */
+export async function getTraktMonths(): Promise<Map<string, TraktMonth>> {
+  const months = new Map<string, TraktMonth>();
+  if (!(await tableExists('trakt_history'))) {
+    return mocksEnabled() ? mockTraktMonths() : months;
+  }
+
+  const localMonth = sql.raw(`date_trunc('month', (watched_at AT TIME ZONE
+    CASE WHEN watched_at < TIMESTAMPTZ '2024-01-01 00:00:00+00'
+    THEN 'Europe/London' ELSE 'America/New_York' END))`);
+
+  const [totals, top, binge] = await Promise.all([
+    db.execute(sql`
+      SELECT to_char(${localMonth}, 'YYYY-MM') AS mon,
+             COUNT(*) FILTER (WHERE type = 'episode') AS episodes,
+             COUNT(*) FILTER (WHERE type = 'movie') AS movies,
+             COUNT(DISTINCT show_title) FILTER (WHERE show_title IS NOT NULL) AS shows
+      FROM trakt_history GROUP BY 1`),
+
+    db.execute(sql`
+      WITH s AS (
+        SELECT ${localMonth} AS mon, show_title, COUNT(*) AS n,
+               ROW_NUMBER() OVER (PARTITION BY ${localMonth} ORDER BY COUNT(*) DESC) AS rn
+        FROM trakt_history WHERE show_title IS NOT NULL GROUP BY 1, 2
+      )
+      SELECT to_char(mon,'YYYY-MM') AS mon, show_title, n FROM s WHERE rn = 1`),
+
+    // Most episodes of one show polished off in a single day.
+    db.execute(sql`
+      WITH d AS (
+        SELECT ${localMonth} AS mon, date_trunc('day', watched_at) AS day, show_title, COUNT(*) AS n
+        FROM trakt_history WHERE show_title IS NOT NULL GROUP BY 1, 2, 3
+      ), r AS (
+        SELECT mon, show_title, n, ROW_NUMBER() OVER (PARTITION BY mon ORDER BY n DESC) AS rn FROM d
+      )
+      SELECT to_char(mon,'YYYY-MM') AS mon, show_title, n FROM r WHERE rn = 1`),
+  ]);
+
+  const ensure = (key: string): TraktMonth => {
+    let m = months.get(key);
+    if (!m) {
+      m = { episodes: 0, movies: 0, shows: 0 };
+      months.set(key, m);
+    }
+    return m;
+  };
+
+  for (const r of totals.rows as Row[]) {
+    const m = ensure(String(r.mon));
+    m.episodes = num(r.episodes);
+    m.movies = num(r.movies);
+    m.shows = num(r.shows);
+  }
+  for (const r of top.rows as Row[]) {
+    ensure(String(r.mon)).topShow = { title: String(r.show_title), count: num(r.n) };
+  }
+  for (const r of binge.rows as Row[]) {
+    if (num(r.n) >= 3) ensure(String(r.mon)).biggestBinge = { title: String(r.show_title), count: num(r.n) };
+  }
+
+  return months;
+}

--- a/utils/reportTz.ts
+++ b/utils/reportTz.ts
@@ -1,0 +1,19 @@
+export type ReportTz = 'America/New_York' | 'Europe/London';
+
+/**
+ * I lived in London until March 2024; from 2024 onwards in NY. Stats are bucketed
+ * in whichever timezone I was actually living in, so "my 2am month" means 2am to me.
+ */
+export function reportTzForDate(date: Date): ReportTz {
+  return date.getUTCFullYear() >= 2024 ? 'America/New_York' : 'Europe/London';
+}
+
+/** The timezone a whole calendar year is reported in. */
+export function reportTz(year: number): ReportTz {
+  return reportTzForDate(new Date(Date.UTC(year, 0, 1)));
+}
+
+/** Hours to add to a local wall-clock time to get UTC, on Jan 1 (always standard time). */
+export function januaryUtcOffset(tz: ReportTz): number {
+  return tz === 'America/New_York' ? 5 : 0;
+}


### PR DESCRIPTION
The homepage was just the corkboard — you scrolled and there was nothing there. Meanwhile 163,797 Last.fm listens spanning **94 contiguous months** (Nov 2018 → now) sat in Postgres, surfaced only by `/wrapped`, which nothing links to.

This adds a timeline below the board: one card per month, newest first, infinite scrolling back to November 2018.

## The cards

Each card is a bento grid of the most interesting stats that month actually has — top artist over its album art, listens, artists, an on-repeat track, a per-day sparkline — rather than a fixed set, so a quiet month doesn't render a row of empty boxes. Every source that has data gets a slot before music takes a second one, otherwise music's richer stats crowd everything else off the card.

## Why there's no query pagination

Computing **all 94 months in one grouped pass costs ~3.4s** — about the same as computing one, because the work is a single `GROUP BY date_trunc('month', …)` either way. So `getMonthSummaries` computes and caches the whole timeline, and pagination is array slicing. Load-more requests come back in **3–5ms** from the cache instead of hitting the DB.

Two consequences worth noting:
- "New artists" is a single `MIN(time) GROUP BY LOWER(artist)` first-seen map (185ms for all time), not a per-month scan of history.
- Month buckets switch timezone mid-history via a SQL `CASE` — London before 2024, New York after — matching the existing `reportTz`, which is extracted to `utils/reportTz.ts` so `/wrapped` and the feed share one definition of the move date.

Verified: every year's feed total reconciles exactly against the database, and the grand total matches `COUNT(*)` on `listens`.

## Degradation

Every source is isolated behind its own `try`/`catch` plus a `to_regclass` probe. A missing table, an unset `POSTGRES_URL`, or the mock DB renders **no feed** rather than an error — `POSTGRES_URL= next build` succeeds with the homepage still static.

**GitHub and Trakt ship dark.** Their source modules are written against tables pulsar doesn't create yet and return nothing until it does. `FEED_MOCK_SOURCES=1` renders deterministic stand-in data for designing against; it never writes to the database and real tables always win.

GitHub will need a **daily contributions table**, not `github_events` — the REST Events API only retains ~90 days, so events can't carry history back to 2018. The contributions GraphQL API backfills to account creation.

## The yarn

The board's yarn continues into the feed: a strand hangs from a scrap pinned to the cork and dangles past the last card, with a pin at each month.

Its offset is a **fraction of the board's height**, not a fixed pixel value — the board is `clamp(560px, 100dvh - 150px, 820px)` and its contents are positioned in percentages, so a fixed offset drifts with viewport height. The lanyard moved up and right to open up the band it hangs in.

Measured clearance (below lanyard / above shoulder): 38px / 10px at 1280×800, 55px / 26px at 1920×1080.

## Checks

- `npm run type-check` passes; production build succeeds, 70/70 pages.
- Pagination terminates cleanly at Nov 2018; past-the-end and malformed cursors return `done: true` without looping.
- Light, dark and blue/pink themes; 1280×800, 1440×900, 1920×1080, 2560×1440 and 375px.

`npm run lint` is broken on `main` independently of this change — eslint 9 rejects `plugin:@next/next/recommended` ("Unexpected top-level property \"name\""), failing on untouched files too. Worth a separate fix.

## Coupling to flag

The feed reaches up into the corkboard's space in three places, all commented at their sites: `--board-h` must match `.board`'s `height`, the placement fraction assumes the lanyard at `top: 16%`, and the mobile placement assumes the board's new bottom padding. The "shoulder" figure above is derived from the avatar artwork rather than read off an element, so it's an estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)